### PR TITLE
feat(next-cloud): resize instance to t4g.small with explicit root volume

### DIFF
--- a/live/management/main.tf
+++ b/live/management/main.tf
@@ -22,6 +22,14 @@ module "next_cloud" {
   user_data                   = file("${path.module}/user_data.sh")
   user_data_replace_on_change = true
 
+  # The AMI's default root volume is too small for the AIO container images,
+  # data dir, and Postgres. Size it explicitly (~30 GB gp3). See ADR-0002.
+  root_block_device = {
+    type      = "gp3"
+    size      = 30
+    encrypted = true
+  }
+
   # Create an instance profile and attach AmazonSSMManagedInstanceCore so
   # sessions open via Session Manager — no SSH key or inbound port 22 required.
   create_iam_instance_profile = true

--- a/live/management/variables.tf
+++ b/live/management/variables.tf
@@ -37,7 +37,7 @@ variable "next_cloud_instance_name" {
 variable "next_cloud_instance_type" {
   description = "EC2 instance type for the Nextcloud server (Graviton/arm64 — must match the arm64 AMI in data.tf)"
   type        = string
-  default     = "t4g.nano"
+  default     = "t4g.small"
 }
 
 variable "ingress_cidr_blocks" {


### PR DESCRIPTION
## What

Resizes the Nextcloud instance so it can actually run the AIO stack.

- `next_cloud_instance_type` default → `t4g.small` (2 GB). `t4g.nano` (0.5 GB) cannot host Apache + Nextcloud + PostgreSQL + Redis — the child containers OOM during setup.
- Adds an explicit **30 GB encrypted gp3** root volume on the `ec2-instance` module, since the AMI default is too small for container images, the AIO data dir, and Postgres.
- Stays Graviton/arm64, consistent with the arm64 AMI in `data.tf`.

See ADR-0002 for the sizing rationale.

## Verification

- `terraform fmt` / `terraform validate` clean.
- `terraform plan` clean: instance shows `instance_type = t4g.small` and a `root_block_device` with `volume_size = 30`, `volume_type = gp3`. (Infra not yet applied — `apply` is the operator step.)

Closes #18