### PR TITLE
feat(next-cloud): provision SSM scratch bucket for Ansible file transfer

### DIFF
--- a/live/management/data.tf
+++ b/live/management/data.tf
@@ -4,3 +4,9 @@
 data "aws_ssm_parameter" "ubuntu" {
   name = "/aws/service/canonical/ubuntu/server-minimal/24.04/stable/current/arm64/hvm/ebs-gp3/ami-id"
 }
+
+# Account ID and region compose the account-regional namespace suffix on the
+# SSM scratch bucket name (see module "ssm_scratch" in main.tf).
+data "aws_caller_identity" "current" {}
+
+data "aws_region" "current" {}

--- a/live/management/main.tf
+++ b/live/management/main.tf
@@ -62,3 +62,56 @@ module "next_cloud_sg" {
   tags = var.tags
 }
 
+# Scratch bucket for the amazon.aws.aws_ssm Ansible connection plugin.
+#
+# The plugin moves module .py files to the instance through S3 via presigned
+# URLs generated on the control node. Contents are throwaway artifacts, so a
+# lifecycle rule expires them after a short window. The instance role gets NO
+# S3 permissions — only the control node's credentials touch this bucket. See
+# ADR-0001.
+#
+# The bucket lives in the account regional namespace: its name is reserved to
+# this account in this region and can never be taken or re-created by another
+# account. Name format is `<prefix>-<account-id>-<region>-an`.
+# https://docs.aws.amazon.com/AmazonS3/latest/userguide/gpbucketnamespaces.html
+module "ssm_scratch" {
+  source  = "terraform-aws-modules/s3-bucket/aws"
+  version = "~> 5.13"
+
+  bucket           = format("%s-%s-%s-an", var.ssm_scratch_bucket_prefix, data.aws_caller_identity.current.account_id, data.aws_region.current.region)
+  bucket_namespace = "account-regional"
+
+  # Transient, controller-side-only artifacts: no public exposure ever.
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+
+  server_side_encryption_configuration = {
+    rule = {
+      apply_server_side_encryption_by_default = {
+        sse_algorithm = "AES256"
+      }
+      bucket_key_enabled = true
+    }
+  }
+
+  # Expire the throwaway transfer artifacts (empty filter == all objects) and
+  # sweep any stalled multipart uploads on the same clock.
+  lifecycle_rule = [
+    {
+      id      = "expire-scratch-objects"
+      enabled = true
+      filter  = {}
+
+      expiration = {
+        days = var.ssm_scratch_expiration_days
+      }
+
+      abort_incomplete_multipart_upload_days = var.ssm_scratch_expiration_days
+    }
+  ]
+
+  tags = var.tags
+}
+

--- a/live/management/outputs.tf
+++ b/live/management/outputs.tf
@@ -1,0 +1,11 @@
+# Consumed by the Ansible layer to point the amazon.aws.aws_ssm connection
+# plugin at its file-transfer side-channel. See ADR-0001.
+output "ssm_scratch_bucket_name" {
+  description = "Name of the S3 scratch bucket for the aws_ssm Ansible connection plugin."
+  value       = module.ssm_scratch.s3_bucket_id
+}
+
+output "ssm_scratch_bucket_region" {
+  description = "Region of the S3 scratch bucket."
+  value       = module.ssm_scratch.s3_bucket_region
+}

--- a/live/management/variables.tf
+++ b/live/management/variables.tf
@@ -45,3 +45,24 @@ variable "ingress_cidr_blocks" {
   type        = list(string)
 }
 
+#########################
+# SSM scratch bucket
+#########################
+
+variable "ssm_scratch_bucket_prefix" {
+  description = "Name prefix for the aws_ssm scratch bucket. The account ID, region, and `-an` namespace suffix are appended (final name: <prefix>-<account-id>-<region>-an)."
+  type        = string
+  default     = "scottishwidow-ssm-scratch"
+}
+
+variable "ssm_scratch_expiration_days" {
+  description = "Days after which scratch-bucket objects (and stalled multipart uploads) are expired. Contents are transient transfer artifacts."
+  type        = number
+  default     = 1
+
+  validation {
+    condition     = var.ssm_scratch_expiration_days >= 1
+    error_message = "Lifecycle expiration must be at least 1 day."
+  }
+}
+


### PR DESCRIPTION
## What

Provisions the S3 scratch bucket the `amazon.aws.aws_ssm` Ansible connection plugin uses as its file-transfer side-channel (module `.py` files move through it via presigned URLs). Added to `live/management/` via the `terraform-aws-modules/s3-bucket/aws` module (`~> 5.13`).

- **Account-regional namespace** — `bucket_namespace = "account-regional"`, name `<prefix>-<account-id>-<region>-an`. Reserved to this account/region; cannot be squatted by another account. ([docs](https://docs.aws.amazon.com/AmazonS3/latest/userguide/gpbucketnamespaces.html))
- **Lifecycle expiry** — objects and stalled multipart uploads expire after 1 day (transient artifacts).
- **Hardened** — all public-access-block flags on; SSE-S3 (AES256) with bucket keys.
- **Outputs** — `ssm_scratch_bucket_name`, `ssm_scratch_bucket_region` for the Ansible layer.
- **Instance IAM role untouched** — presigned URLs mean only the control node touches the bucket (ADR-0001).

## Acceptance criteria

- [x] Dedicated S3 bucket via Terraform, distinct from the TF state bucket
- [x] Lifecycle rule expires objects after a short window (1 day)
- [x] Bucket name and region exposed as outputs
- [x] Instance IAM role unchanged (no S3 permissions)

## Validation

- `terraform fmt -check` on changed files — clean
- `terraform init -backend=false` — module 5.13.0, provider v6.47.0 (≥ 6.42, required for `bucket_namespace`)
- `terraform validate` — Success

`terraform plan`/`apply` left to the operator (needs AWS creds + remote state).

Closes #19