### PR TITLE
feat(next-cloud): public networking with EIP, open 80/443, domain var

### DIFF
--- a/live/management/CONTEXT.md
+++ b/live/management/CONTEXT.md
@@ -34,3 +34,29 @@ _Avoid_: state bucket (that is the separate Terraform backend bucket).
 **SSM connection**:
 The `amazon.aws.aws_ssm` Ansible connection plugin. The only transport to the
 instance — no SSH, no inbound 22. See ADR-0001.
+
+**Public address**:
+An Elastic IP (the ec2-instance module's `create_eip`) gives the instance a stable
+address that survives the instance replacement triggered by `user_data` edits. The data plane
+is world-facing: the security group opens 80/443 to `0.0.0.0/0` so AIO can serve
+clients and complete Let's Encrypt HTTP-01 validation. The control plane stays
+SSM-only.
+_Avoid_: confusing this with the auto-assigned public IP (not durable).
+
+## Out-of-band: Route 53 A record
+
+Route 53 is **not** managed by Terraform here (importing the existing zone is out
+of scope — see issue #20). After `terraform apply`, point the `domain` at the EIP
+manually. This is a HITL follow-up step, run once the EIP exists:
+
+```sh
+cd live/management
+DOMAIN=$(terraform output -raw next_cloud_domain)
+EIP=$(terraform output -raw next_cloud_public_ip)
+aws route53 change-resource-record-sets \
+  --hosted-zone-id Z01225632CGMCYQJ151NK \
+  --change-batch "{\"Changes\":[{\"Action\":\"UPSERT\",\"ResourceRecordSet\":{\"Name\":\"${DOMAIN}\",\"Type\":\"A\",\"TTL\":300,\"ResourceRecords\":[{\"Value\":\"${EIP}\"}]}}]}"
+```
+
+`UPSERT` is idempotent — safe to re-run if the EIP ever changes. Verify with
+`dig +short ${DOMAIN}` once propagated.

--- a/live/management/main.tf
+++ b/live/management/main.tf
@@ -30,6 +30,14 @@ module "next_cloud" {
     encrypted = true
   }
 
+  # Stable public address. `user_data_replace_on_change` replaces the instance on
+  # any bootstrap-script edit, so its auto-assigned public IP is not durable. The
+  # EIP allocation persists across replacement (only its instance binding updates),
+  # keeping the Route 53 A record valid. See issue #20.
+  create_eip = true
+  eip_domain = "vpc"
+  eip_tags   = { Name = var.next_cloud_instance_name }
+
   # Create an instance profile and attach AmazonSSMManagedInstanceCore so
   # sessions open via Session Manager — no SSH key or inbound port 22 required.
   create_iam_instance_profile = true
@@ -54,7 +62,10 @@ module "next_cloud_sg" {
   description = "Nextcloud instance: HTTP/HTTPS inbound only"
   vpc_id      = module.vpc.vpc_id
 
-  ingress_cidr_blocks = var.ingress_cidr_blocks
+  # Data plane is intentionally world-facing: AIO terminates TLS and needs 80/443
+  # reachable from anywhere for HTTP-01 cert issuance and normal client access.
+  # The control plane stays SSM-only (no inbound 22). See issue #20.
+  ingress_cidr_blocks = ["0.0.0.0/0"]
   ingress_rules       = ["http-80-tcp", "https-443-tcp"]
 
   egress_rules = ["all-all"]

--- a/live/management/outputs.tf
+++ b/live/management/outputs.tf
@@ -1,3 +1,15 @@
+# Stable public address. Consumed by the out-of-band Route 53 step (A record
+# domain -> this IP) and by Ansible/AIO as the host's reachable address.
+output "next_cloud_public_ip" {
+  description = "Elastic IP address associated with the Nextcloud instance."
+  value       = module.next_cloud.public_ip
+}
+
+output "next_cloud_domain" {
+  description = "Public domain the Nextcloud A record should point at."
+  value       = var.domain
+}
+
 # Consumed by the Ansible layer to point the amazon.aws.aws_ssm connection
 # plugin at its file-transfer side-channel. See ADR-0001.
 output "ssm_scratch_bucket_name" {

--- a/live/management/variables.tf
+++ b/live/management/variables.tf
@@ -40,9 +40,9 @@ variable "next_cloud_instance_type" {
   default     = "t4g.small"
 }
 
-variable "ingress_cidr_blocks" {
-  description = "List of allowed CIDR Blocks for Inbound Traffic"
-  type        = list(string)
+variable "domain" {
+  description = "Public domain for the Nextcloud instance. Points at the Elastic IP via a Route 53 A record (created out-of-band; see CONTEXT.md) and is the name AIO requests a Let's Encrypt cert for. Set in secret.auto.tfvars."
+  type        = string
 }
 
 #########################


### PR DESCRIPTION
Closes #20.

Makes the Nextcloud **data plane** reachable on a stable public address so AIO can serve clients and complete Let's Encrypt HTTP-01 validation. The control plane stays SSM-only.

## Changes
- **Elastic IP** via the ec2-instance module's `create_eip` (`eip_domain = "vpc"`). The allocation survives the instance replacement triggered by `user_data` edits — only its instance binding updates — so the address (and the DNS A record) stays valid.
- **Security group** opens 80/443 to `0.0.0.0/0`. No inbound 22; SSM remains the only control-plane transport.
- **`domain` variable** (required, set in the gitignored `secret.auto.tfvars`) plus `next_cloud_public_ip` / `next_cloud_domain` outputs for the out-of-band Route 53 step.
- Retired the unused `ingress_cidr_blocks` variable.

## Out of scope — Route 53 (HITL follow-up)
Route 53 is not managed by Terraform (importing the existing zone is out of scope). After apply, the A record is created via AWS CLI — command documented in `live/management/CONTEXT.md`. `UPSERT`, idempotent.

## Validation
- `terraform fmt -check` ✅
- `terraform validate` ✅ — Success
- `terraform plan` ✅ — **16 to add, 0 to change, 0 to destroy** (state is currently empty; plan provisions the full stack). EIP shows `domain = "vpc"`; SG ingress shows HTTP/HTTPS from `0.0.0.0/0`.

## Acceptance criteria
- [x] Elastic IP allocated and associated with the instance
- [x] Security group allows inbound 80/443 from `0.0.0.0/0`
- [x] New `domain` variable threaded into Terraform
- [x] Unused `ingress_cidr_blocks` variable retired

> Not applied. `0.0.0.0/0` on 80/443 is intentional (the point of the service) and will trip generic SG-open scanners.