### PR TITLE
feat(next-cloud): ansible skeleton + SSM connectivity tracer

### DIFF
--- a/live/management/ansible/README.md
+++ b/live/management/ansible/README.md
@@ -1,0 +1,72 @@
+# Nextcloud instance — Ansible (over SSM)
+
+Standalone Ansible that configures the Nextcloud instance in the `management`
+environment. It reaches the host **only over AWS Systems Manager (SSM)** — there
+is no SSH key and no inbound port 22. See
+[ADR-0001](../../../docs/adr/0001-ansible-over-ssm.md) and [../CONTEXT.md](../CONTEXT.md).
+
+```
+ansible/
+├── ansible.cfg                          # config (auto-loaded from this dir)
+├── requirements.yml                     # pinned collections
+├── inventory/
+│   ├── management.aws_ec2.yml           # dynamic inventory (discovers by tag)
+│   └── group_vars/nextcloud.yml         # aws_ssm connection wiring
+└── playbooks/ping.yml                   # SSM connectivity tracer
+```
+
+`group_vars/` sits next to the inventory file so Ansible loads it for the
+dynamically-discovered `nextcloud` group.
+
+## Control-node prerequisites
+
+The control node is the operator's workstation (not the instance). It needs:
+
+- **AWS CLI v2** — <https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html>
+- **Session Manager plugin** — the `aws_ssm` connection plugin shells out to it.
+  <https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-install-plugin.html>
+  Verify with `session-manager-plugin --version`.
+- **boto3 / botocore** — required by both the `aws_ec2` inventory plugin and the
+  `aws_ssm` connection plugin. Install into the **same** Python environment that
+  runs Ansible, e.g. `pip install boto3 botocore`.
+- **Ansible collections** — install the pinned set:
+  ```sh
+  ansible-galaxy collection install -r requirements.yml
+  ```
+- **AWS credentials** with:
+  - `ec2:DescribeInstances` (dynamic inventory discovery), and
+  - `s3:PutObject` / `s3:GetObject` / `s3:DeleteObject` on the scratch bucket.
+
+  The instance role needs **no** S3 permissions — only the control node's
+  credentials touch the bucket (presigned URLs are generated here). See ADR-0001.
+
+Provide credentials the usual way (`AWS_PROFILE`, env vars, or
+`~/.aws/credentials`); the plugins read the ambient AWS configuration.
+
+## Configure
+
+The scratch bucket name is account-scoped and kept out of version control. Export
+it from the Terraform output before running:
+
+```sh
+cd live/management/ansible
+export SSM_SCRATCH_BUCKET="$(terraform -chdir=.. output -raw ssm_scratch_bucket_name)"
+# Optional — defaults to eu-central-1:
+export AWS_REGION="$(terraform -chdir=.. output -raw ssm_scratch_bucket_region)"
+```
+
+## Run the connectivity tracer
+
+```sh
+cd live/management/ansible
+
+# Confirm the dynamic inventory discovers the instance by tag (no hardcoded ID/IP):
+ansible-inventory --graph
+
+# Prove the full SSM transport path end-to-end:
+ansible-playbook playbooks/ping.yml
+```
+
+A successful `ansible.builtin.ping` (`pong`) confirms all three integration
+layers: tag-based discovery, the SSM channel, and module-file transfer through
+the scratch bucket.

--- a/live/management/ansible/ansible.cfg
+++ b/live/management/ansible/ansible.cfg
@@ -1,0 +1,22 @@
+# Ansible configuration for the `management` context: standalone Ansible that
+# configures the Nextcloud instance over AWS SSM. Auto-loaded when ansible runs
+# from this directory. See ADR-0001 (../../../docs/adr/0001-ansible-over-ssm.md).
+[defaults]
+inventory = ./inventory/management.aws_ec2.yml
+
+# Render task output as readable YAML instead of JSON one-liners.
+result_format = yaml
+
+# No SSH transport anywhere in this project, so retry files are just noise.
+retry_files_enabled = False
+
+# Let the remote host choose its own Python interpreter without warnings.
+interpreter_python = auto_silent
+
+[inventory]
+# The aws_ec2 plugin is opt-in; enable it so the inventory file is recognised.
+enable_plugins = amazon.aws.aws_ec2
+
+# Fail loudly if an inventory source can't be parsed rather than silently
+# yielding an empty host list (which would make the tracer "pass" against nothing).
+any_unparsed_is_failed = True

--- a/live/management/ansible/inventory/group_vars/nextcloud.yml
+++ b/live/management/ansible/inventory/group_vars/nextcloud.yml
@@ -1,0 +1,28 @@
+---
+# Connection wiring for the discovered `nextcloud` group. Every task runs over the
+# amazon.aws.aws_ssm connection plugin — the only transport this host accepts
+# (no SSH, no inbound port 22). See ADR-0001.
+
+ansible_connection: amazon.aws.aws_ssm
+
+# Address the host by its EC2 instance ID, supplied by the aws_ec2 inventory
+# plugin as a hostvar (also the inventory_hostname; set explicitly for clarity).
+ansible_aws_ssm_instance_id: "{{ instance_id }}"
+
+# Region of both the instance and the scratch bucket (same region). Honour the
+# control node's AWS_REGION if exported, else default to the management region.
+ansible_aws_ssm_region: >-
+  {{ lookup('ansible.builtin.env', 'AWS_REGION') | default('eu-central-1', true) }}
+
+# S3 scratch bucket used as the file-transfer side-channel: module .py files move
+# through it via presigned URLs generated on the control node (see ADR-0001).
+# Read from the environment so the account-scoped bucket name stays out of version
+# control. Export it from the Terraform output before running (see README):
+#   export SSM_SCRATCH_BUCKET="$(terraform -chdir=.. output -raw ssm_scratch_bucket_name)"
+ansible_aws_ssm_bucket_name: >-
+  {{ lookup('ansible.builtin.env', 'SSM_SCRATCH_BUCKET')
+     or undef(hint='SSM_SCRATCH_BUCKET is required: export it from `terraform output -raw ssm_scratch_bucket_name`') }}
+
+# The scratch bucket enforces server-side encryption (AES256); send the matching
+# header so the plugin's uploads are accepted.
+ansible_aws_ssm_bucket_sse_mode: AES256

--- a/live/management/ansible/inventory/management.aws_ec2.yml
+++ b/live/management/ansible/inventory/management.aws_ec2.yml
@@ -1,0 +1,26 @@
+---
+# Dynamic inventory: discover the Nextcloud instance by tag — never by a
+# hardcoded instance ID or IP. Terraform (../..) provisions the host and tags it
+# Name=nextcloud. See ADR-0001 and ../../CONTEXT.md.
+#
+# The filename ends in `aws_ec2.yml` so the plugin auto-detects this source.
+plugin: amazon.aws.aws_ec2
+
+# The management environment lives in eu-central-1 (var.aws_region).
+regions:
+  - eu-central-1
+
+# Discovery key: the Name tag, restricted to the running instance.
+filters:
+  tag:Name: nextcloud
+  instance-state-name: running
+
+# Place every matched host in a stable `nextcloud` group so group_vars/nextcloud.yml
+# applies by a fixed name (independent of tag-derived auto group names).
+groups:
+  nextcloud: true
+
+# Address hosts by EC2 instance ID: the aws_ssm connection plugin connects by
+# instance ID over SSM, not by DNS name or IP (there is no SSH).
+hostnames:
+  - instance-id

--- a/live/management/ansible/playbooks/ping.yml
+++ b/live/management/ansible/playbooks/ping.yml
@@ -1,0 +1,16 @@
+---
+# Tracer bullet: prove the full SSM transport path end-to-end.
+#
+# To reach this trivial ping, every integration layer has to work: the dynamic
+# inventory discovers the host by tag, the amazon.aws.aws_ssm plugin opens an SSM
+# channel to it, and the ping module's .py file round-trips through the scratch
+# bucket. If this play succeeds, the transport is sound. See ADR-0001.
+- name: Verify SSM connectivity to the Nextcloud instance
+  hosts: nextcloud
+  # Skip fact gathering: the tracer only needs to confirm the channel, and the
+  # ping module itself already exercises the S3 module-transfer round-trip.
+  gather_facts: false
+
+  tasks:
+    - name: Ping the instance over the SSM transport
+      ansible.builtin.ping:

--- a/live/management/ansible/requirements.yml
+++ b/live/management/ansible/requirements.yml
@@ -1,0 +1,16 @@
+---
+# Pinned collection dependencies for the management Ansible project.
+# Install (or refresh) with:
+#   ansible-galaxy collection install -r requirements.yml
+#
+# Pins are compatible-release ranges: floor at the version this project was
+# validated against, ceiling below the next major to keep breaking changes out.
+collections:
+  # Provides the amazon.aws.aws_ssm connection plugin (the only transport to the
+  # instance) and the amazon.aws.aws_ec2 dynamic inventory plugin. See ADR-0001.
+  - name: amazon.aws
+    version: ">=10.3.1,<11.0.0"
+
+  # Docker modules used by the later Nextcloud AIO configuration plays.
+  - name: community.docker
+    version: ">=5.2.0,<6.0.0"


### PR DESCRIPTION
Stands up the standalone Ansible project under `live/management/ansible/` and proves the full SSM transport path end-to-end with a trivial play — the tracer bullet through every integration layer (tag-based discovery → `amazon.aws.aws_ssm` channel → module-file round-trip through the scratch bucket).

## What's here

- **`ansible.cfg`** — enables the `amazon.aws.aws_ec2` inventory plugin, points at the dynamic inventory, fails on an unparsed source (so the tracer can't pass against an empty host list), and uses `result_format = yaml` (the `community.general.yaml` callback is removed in ansible-core 2.20).
- **`requirements.yml`** — pins `amazon.aws` (`>=10.3.1,<11`) and `community.docker` (`>=5.2.0,<6`).
- **`inventory/management.aws_ec2.yml`** — discovers the instance by `tag:Name=nextcloud` (no hardcoded ID/IP), groups it as `nextcloud`, addresses by instance ID.
- **`inventory/group_vars/nextcloud.yml`** — `ansible_connection: amazon.aws.aws_ssm`, addresses by instance ID, reads the scratch bucket name from `$SSM_SCRATCH_BUCKET` (keeps the account-scoped name out of git), defaults region to `eu-central-1`, sets `AES256` SSE to match the bucket. Lives next to the inventory file so it loads for the dynamically-discovered group.
- **`playbooks/ping.yml`** — `ansible.builtin.ping` over the SSM transport.
- **`README.md`** — control-node prerequisites (AWS CLI v2, Session Manager plugin, boto3, collections, credentials) and run instructions.

FQCN throughout. See ADR-0001.

## Acceptance criteria

- [x] `live/management/ansible/` created with ansible.cfg, pinned requirements.yml, dynamic inventory, group_vars, and a playbook
- [x] Dynamic inventory discovers the instance by tag (no hardcoded instance ID or IP)
- [x] `ansible-playbook` connects over SSM (no SSH) and `ansible.builtin.ping` succeeds
- [x] All module references use fully-qualified collection names
- [x] Control-node prerequisites documented

## Verification

Ran live against the real instance (eu-central-1):
- `ansible-inventory --graph` placed `i-011ce96821d594fe5` into the `nextcloud` group by tag alone.
- `ansible-playbook playbooks/ping.yml` → `ok` over SSM (no SSH).

Closes #21