### PR TITLE
feat(next-cloud): nextcloud_aio role — AIO mastercontainer (base stack)

### DIFF
--- a/live/management/ansible/README.md
+++ b/live/management/ansible/README.md
@@ -12,7 +12,11 @@ ansible/
 ├── inventory/
 │   ├── management.aws_ec2.yml           # dynamic inventory (discovers by tag)
 │   └── group_vars/nextcloud.yml         # aws_ssm connection wiring
-└── playbooks/ping.yml                   # SSM connectivity tracer
+├── roles/
+│   └── nextcloud_aio/                   # AIO mastercontainer (base stack)
+└── playbooks/
+    ├── ping.yml                         # SSM connectivity tracer
+    └── nextcloud-aio.yml                # deploy the AIO mastercontainer
 ```
 
 `group_vars/` sits next to the inventory file so Ansible loads it for the
@@ -70,3 +74,41 @@ ansible-playbook playbooks/ping.yml
 A successful `ansible.builtin.ping` (`pong`) confirms all three integration
 layers: tag-based discovery, the SSM channel, and module-file transfer through
 the scratch bucket.
+
+## Deploy the AIO mastercontainer
+
+Brings up the Nextcloud AIO mastercontainer in its default built-in-Apache mode,
+base stack only (Apache + Nextcloud + PostgreSQL + Redis). The AIO admin interface
+on 8080 is bound to `127.0.0.1` — never internet-exposed. See the
+[`nextcloud_aio` role](roles/nextcloud_aio/README.md).
+
+```sh
+cd live/management/ansible
+ansible-playbook playbooks/nextcloud-aio.yml
+```
+
+Re-running is idempotent: the play reports `ok` (not `changed`) once the
+mastercontainer is up.
+
+### Verify the AIO mastercontainer
+
+The admin interface is bound to localhost on the instance, so reach it with an
+SSM **port-forward** — no public exposure, no SSH:
+
+```sh
+# Discover the instance by tag (same key the inventory uses):
+INSTANCE_ID=$(aws ec2 describe-instances \
+  --filters Name=tag:Name,Values=nextcloud Name=instance-state-name,Values=running \
+  --query 'Reservations[].Instances[].InstanceId' --output text)
+
+# Forward local 8080 -> instance 8080 over SSM (leave this running):
+aws ssm start-session \
+  --target "$INSTANCE_ID" \
+  --document-name AWS-StartPortForwardingSession \
+  --parameters '{"portNumber":["8080"],"localPortNumber":["8080"]}'
+```
+
+Then open <https://localhost:8080> in a browser. AIO serves the admin interface
+over HTTPS with a self-signed certificate, so accept the browser warning; the
+**AIO setup page** (showing the initial admin password) confirms the
+mastercontainer is up.

--- a/live/management/ansible/ansible.cfg
+++ b/live/management/ansible/ansible.cfg
@@ -4,6 +4,10 @@
 [defaults]
 inventory = ./inventory/management.aws_ec2.yml
 
+# Resolve roles from this directory's roles/ regardless of where a playbook lives
+# (playbooks sit under playbooks/, roles under roles/).
+roles_path = ./roles
+
 # Render task output as readable YAML instead of JSON one-liners.
 result_format = yaml
 

--- a/live/management/ansible/playbooks/nextcloud-aio.yml
+++ b/live/management/ansible/playbooks/nextcloud-aio.yml
@@ -1,0 +1,13 @@
+---
+# Deploy the Nextcloud AIO mastercontainer (base stack) on the instance.
+#
+# Runs over the SSM transport (see ADR-0001). become escalates to root for the
+# apt install and Docker socket access — the SSM session's ssm-user has
+# passwordless sudo.
+- name: Deploy Nextcloud AIO mastercontainer
+  hosts: nextcloud
+  gather_facts: false
+  become: true
+
+  roles:
+    - nextcloud_aio

--- a/live/management/ansible/roles/nextcloud_aio/README.md
+++ b/live/management/ansible/roles/nextcloud_aio/README.md
@@ -1,0 +1,34 @@
+# `nextcloud_aio` role
+
+Brings up the **Nextcloud AIO mastercontainer** in its default **built-in-Apache**
+mode — base stack only (Apache + Nextcloud + PostgreSQL + Redis), no optional
+containers. See [../../../CONTEXT.md](../../../CONTEXT.md) for the AIO / mastercontainer
+language and [ADR-0001](../../../../docs/adr/0001-ansible-over-ssm.md) for the SSM transport.
+
+## What it does
+
+1. Asserts Docker Engine is present and reachable, failing clearly if not —
+   Docker is installed by `user_data` at first boot (`live/management/user_data.sh`),
+   not by this role.
+2. Installs the Python Docker SDK (`python3-docker`) the `community.docker`
+   modules need on the host.
+3. Reconciles the `nextcloud/all-in-one` mastercontainer via
+   `community.docker.docker_container` — idempotent on re-run.
+
+The AIO admin interface (8080) is bound to **`127.0.0.1`**, so it is never
+internet-exposed. The public data plane (80/443, TLS, domain) is a separate slice.
+
+## Requires
+
+- `become: true` (apt install + Docker socket access).
+- The `community.docker` collection (pinned in `../../requirements.yml`).
+
+## Variables
+
+See [`defaults/main.yml`](defaults/main.yml). The volume name
+`nextcloud_aio_mastercontainer` is hardcoded by AIO and must not be changed.
+
+## Verify
+
+After running `playbooks/nextcloud-aio.yml`, port-forward 8080 over SSM and open
+the AIO setup page — see the project [README](../../README.md#verify-the-aio-mastercontainer).

--- a/live/management/ansible/roles/nextcloud_aio/defaults/main.yml
+++ b/live/management/ansible/roles/nextcloud_aio/defaults/main.yml
@@ -1,0 +1,32 @@
+---
+# Defaults for the nextcloud_aio role: bring up the Nextcloud AIO mastercontainer
+# in its default built-in-Apache mode, base stack only (Apache + Nextcloud +
+# PostgreSQL + Redis). See ../../README.md and ../../../CONTEXT.md.
+
+# AIO mastercontainer image. Nextcloud ships AIO as a self-updating stack pinned
+# by *channel* tag, not by a frozen version: the mastercontainer pulls and manages
+# the inner containers itself. `latest` is the stable channel Nextcloud documents
+# for production. Multi-arch, so it runs on this Graviton/arm64 host.
+nextcloud_aio_image: nextcloud/all-in-one:latest
+
+# Container name. Kept stable so re-runs reconcile the same container.
+nextcloud_aio_mastercontainer_name: nextcloud-aio-mastercontainer
+
+# Named volume holding the mastercontainer's own config/state. AIO hardcodes this
+# exact name internally — do NOT change it, or the mastercontainer will not find
+# its state. See https://github.com/nextcloud/all-in-one#how-to-use-this.
+nextcloud_aio_config_volume: nextcloud_aio_mastercontainer
+
+# Host interface the AIO admin interface (8080) binds to. 127.0.0.1 keeps the
+# admin interface off the internet entirely — it is reached only via an SSM
+# port-forward, never the public address. The public data plane (80/443) is a
+# separate slice.
+nextcloud_aio_admin_bind: "127.0.0.1"
+
+# Admin interface port inside the container and on the bound interface.
+nextcloud_aio_admin_port: 8080
+
+# APT package providing the Python Docker SDK that the community.docker modules
+# import on the host. Installed from Ubuntu's archive (not pip) to stay clear of
+# PEP 668 externally-managed-environment errors on the system interpreter.
+nextcloud_aio_docker_sdk_package: python3-docker

--- a/live/management/ansible/roles/nextcloud_aio/tasks/main.yml
+++ b/live/management/ansible/roles/nextcloud_aio/tasks/main.yml
@@ -1,0 +1,50 @@
+---
+# Bring up the Nextcloud AIO mastercontainer (base stack, default built-in-Apache
+# mode). Docker Engine itself is installed by user_data at first boot, not here;
+# this role asserts it is present, adds the Python Docker SDK the community.docker
+# modules need, then reconciles the mastercontainer.
+
+- name: Probe for the Docker daemon
+  # Docker is installed by live/management/user_data.sh at first boot, not by
+  # Ansible. Probe non-fatally so the next task can emit a clear, actionable
+  # failure rather than an opaque socket error from docker_container.
+  ansible.builtin.command: docker info
+  register: nextcloud_aio_docker_info
+  changed_when: false
+  failed_when: false
+
+- name: Assert Docker Engine is present and reachable
+  ansible.builtin.assert:
+    that:
+      - nextcloud_aio_docker_info.rc == 0
+    fail_msg: >-
+      Docker Engine is not available on the Nextcloud instance. It is installed by
+      user_data at first boot (live/management/user_data.sh), not by Ansible.
+      `docker info` exited {{ nextcloud_aio_docker_info.rc }}. Confirm the instance
+      bootstrapped successfully before re-running this play.
+    success_msg: Docker Engine is present and reachable.
+
+- name: Install the Python Docker SDK (required by the community.docker modules)
+  ansible.builtin.apt:
+    name: "{{ nextcloud_aio_docker_sdk_package }}"
+    state: present
+    update_cache: true
+    cache_valid_time: 3600
+
+- name: Run the Nextcloud AIO mastercontainer
+  # Default built-in-Apache mode: no APACHE_PORT / reverse-proxy env, no optional
+  # containers. The mastercontainer manages the inner stack via the Docker socket
+  # (mounted read-only) and serves the AIO admin interface on 8080, bound to
+  # localhost only. Idempotent: on re-run the container already matches this spec,
+  # so the module reports ok rather than recreating it.
+  community.docker.docker_container:
+    name: "{{ nextcloud_aio_mastercontainer_name }}"
+    image: "{{ nextcloud_aio_image }}"
+    state: started
+    restart_policy: always
+    init: true
+    published_ports:
+      - "{{ nextcloud_aio_admin_bind }}:{{ nextcloud_aio_admin_port }}:8080"
+    volumes:
+      - "{{ nextcloud_aio_config_volume }}:/mnt/docker-aio-config"
+      - /var/run/docker.sock:/var/run/docker.sock:ro


### PR DESCRIPTION
## What

Adds a `nextcloud_aio` Ansible role that brings up the Nextcloud AIO **mastercontainer** in its default **built-in-Apache** mode, base stack only (Apache + Nextcloud + PostgreSQL + Redis). No optional containers.

The role:
- **Asserts Docker Engine is present** (installed by `user_data` at first boot, not by Ansible) and fails clearly — pointing at `user_data.sh` — if `docker info` is unreachable.
- **Installs the Python Docker SDK** (`python3-docker` via apt, avoiding PEP 668 errors on the system interpreter) that the `community.docker` modules need.
- **Runs the mastercontainer** via `community.docker.docker_container`, idempotent on re-run, with the AIO admin interface (**8080**) bound to **`127.0.0.1`** so it is never internet-exposed. Docker socket mounted read-only.

The public data plane (80/443, TLS, domain) is a separate slice. Verification here is via an **SSM port-forward** to 8080 (documented in the README).

## Files
- `roles/nextcloud_aio/{tasks,defaults}/main.yml` + role README
- `playbooks/nextcloud-aio.yml` — deploy play (`become: true`, over SSM)
- `ansible.cfg` — `roles_path = ./roles` so playbooks resolve the role
- `README.md` — deploy + SSM port-forward verification section

## Acceptance criteria
- [x] Role asserts Docker is present, fails clearly if not
- [x] Installs the Python Docker SDK on the host
- [x] Mastercontainer via `community.docker.docker_container`, idempotent
- [x] Built-in-Apache default mode; no optional containers
- [x] Admin interface bound to `127.0.0.1:8080`
- [x] SSM port-forward to 8080 shows the AIO setup page (documented)

## Validation
- `ansible-playbook --syntax-check` passes; role resolves via `roles_path`.
- Confirmed `init` / `published_ports` / `restart_policy` / `volumes` are valid params against installed `community.docker` 5.2.0.

## Note
Image pinned to `nextcloud/all-in-one:latest` — AIO is a self-updating stack pinned by *channel* tag (the mastercontainer manages inner-container versions), and `latest` is the channel Nextcloud documents for production.

Closes #22.