### PR TITLE
feat(next-cloud): persistent swap file to prevent OOM kills

### DIFF
--- a/live/management/ansible/playbooks/nextcloud-aio.yml
+++ b/live/management/ansible/playbooks/nextcloud-aio.yml
@@ -5,4 +5,5 @@
   become: true
 
   roles:
+    - system_swap
     - nextcloud_aio

--- a/live/management/ansible/roles/system_swap/README.md
+++ b/live/management/ansible/roles/system_swap/README.md
@@ -1,0 +1,31 @@
+# `system_swap` role
+
+Provisions a persistent **swap file** on the instance. The Nextcloud box is a
+`t4g.small` (2 GB RAM) with no swap by default; under load the full AIO stack can
+exhaust memory and trip the kernel **OOM killer** (observed killing Collabora
+workers, leaving the stack degraded). A small swap file gives the kernel an
+overflow buffer instead of killing processes outright.
+
+Runs **before** `nextcloud_aio` so swap exists before the stack starts.
+
+## What it does
+
+1. Allocates `{{ system_swap_file }}` (default `/swapfile`, `2048` MB) if missing,
+   `0600` root-only.
+2. Formats it with `mkswap` (skipped if it already carries a swap signature).
+3. Persists it in `/etc/fstab` and enables it with `swapon` — idempotent on re-run.
+4. Sets `vm.swappiness={{ system_swap_swappiness }}` (default `10`) via
+   `/etc/sysctl.d/99-swappiness.conf` so swap is overflow, not first resort.
+
+## Requires
+
+- `become: true` (writes to `/`, `/etc/fstab`, `/etc/sysctl.d`, calls `swapon`).
+
+## Variables
+
+See [`defaults/main.yml`](defaults/main.yml).
+
+## Verify
+
+`swapon --show` should list `/swapfile`; `free -m` should report a non-zero
+`Swap` total.

--- a/live/management/ansible/roles/system_swap/defaults/main.yml
+++ b/live/management/ansible/roles/system_swap/defaults/main.yml
@@ -1,0 +1,6 @@
+---
+system_swap_file: /swapfile
+
+system_swap_size_mb: 2048
+
+system_swap_swappiness: 10

--- a/live/management/ansible/roles/system_swap/handlers/main.yml
+++ b/live/management/ansible/roles/system_swap/handlers/main.yml
@@ -1,0 +1,5 @@
+---
+- name: Reload swappiness sysctl
+  ansible.builtin.command:
+    cmd: sysctl -p /etc/sysctl.d/99-swappiness.conf
+  changed_when: false

--- a/live/management/ansible/roles/system_swap/tasks/main.yml
+++ b/live/management/ansible/roles/system_swap/tasks/main.yml
@@ -1,0 +1,58 @@
+---
+- name: Check whether the swap file already exists
+  ansible.builtin.stat:
+    path: "{{ system_swap_file }}"
+  register: system_swap_stat
+
+- name: Allocate the swap file
+  ansible.builtin.command:
+    cmd: "dd if=/dev/zero of={{ system_swap_file }} bs=1M count={{ system_swap_size_mb }}"
+  args:
+    creates: "{{ system_swap_file }}"
+  when: not system_swap_stat.stat.exists
+
+- name: Secure the swap file (root-only, 0600)
+  ansible.builtin.file:
+    path: "{{ system_swap_file }}"
+    owner: root
+    group: root
+    mode: "0600"
+
+- name: Detect an existing swap signature on the file
+  ansible.builtin.command:
+    cmd: "blkid -t TYPE=swap {{ system_swap_file }}"
+  register: system_swap_sig
+  changed_when: false
+  failed_when: false
+
+- name: Format the swap file
+  ansible.builtin.command:
+    cmd: "mkswap {{ system_swap_file }}"
+  when: system_swap_sig.rc != 0
+
+- name: Persist the swap file in /etc/fstab
+  ansible.builtin.lineinfile:
+    path: /etc/fstab
+    line: "{{ system_swap_file }} none swap sw 0 0"
+    regexp: "^{{ system_swap_file | regex_escape }}\\s"
+    state: present
+
+- name: Check whether the swap file is currently active
+  ansible.builtin.command:
+    cmd: swapon --noheadings --show=NAME
+  register: system_swap_active
+  changed_when: false
+
+- name: Enable the swap file
+  ansible.builtin.command:
+    cmd: "swapon {{ system_swap_file }}"
+  when: system_swap_file not in system_swap_active.stdout
+
+- name: Set vm.swappiness (persisted)
+  ansible.builtin.copy:
+    dest: /etc/sysctl.d/99-swappiness.conf
+    content: "vm.swappiness={{ system_swap_swappiness }}\n"
+    owner: root
+    group: root
+    mode: "0644"
+  notify: Reload swappiness sysctl


### PR DESCRIPTION
## Why

The Nextcloud instance (`t4g.small`, 2 GB RAM) was provisioned with **no swap**. Under load the full AIO stack exhausts memory and trips the kernel **OOM killer** — confirmed in the kernel log on 2026-06-14, where a system-wide OOM (`global_oom`, `CONSTRAINT_NONE`) killed Collabora worker processes (`kit_spare_*`), leaving the stack degraded until a manual reboot. The box sits at ~1.4/1.8 GB used even idle, with ~400 MB headroom.

## What

- New **`system_swap`** role: allocates a 2 GB `/swapfile` (`0600`, persisted in `/etc/fstab`), formats it, enables it, and sets `vm.swappiness=10` via `/etc/sysctl.d/99-swappiness.conf`. Idempotent on re-run.
- Wired into `playbooks/nextcloud-aio.yml` **before** `nextcloud_aio` so swap exists before the stack starts.

The same change has already been applied live on the instance (swap is active now); this PR makes it survive a rebuild.

## Not in this PR

- **Disabling Collabora** (the actual memory hog) is an action in the AIO admin UI and isn't expressible in the role — the role only manages the mastercontainer; addon selection is internal AIO state.
- The smoke-test runbook still expects "7 AIO containers"; that drops to 6 once Collabora is disabled. Can follow up separately.

## Test

`ansible-playbook --syntax-check` passes. Live verification: `swapon --show` lists `/swapfile`; `free -m` reports `Swap: 2047`.